### PR TITLE
Fix broken anchor tag in TheWelcome.vue

### DIFF
--- a/frontend/src/components/TheWelcome.vue
+++ b/frontend/src/components/TheWelcome.vue
@@ -43,8 +43,7 @@ const openReadmeInEditor = () => fetch('/__open-in-editor?file=README.md')
     <br />
 
     More instructions are available in
-    <a href="javascript:void(0)" @click="openReadmeInEditor"><code>README.md</code></a
-    >.
+    <a href="javascript:void(0)" @click="openReadmeInEditor"><code>README.md</code></a>.
   </WelcomeItem>
 
   <WelcomeItem>


### PR DESCRIPTION
## Summary
- fix malformed closing anchor tag in TheWelcome.vue

## Testing
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_683fdc57184083278d32e8fa9ccddba9